### PR TITLE
Make this crate Windows-friendly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 git = "https://github.com/rhelmer/range-map.git"
 
 [dependencies]
-nom = "~0.5.0"
+nom = "~1.2.2"
 # This is technically test-dependencies, but cargo can't handle that
 # when running `cargo test -p breakpad-symbols` from the repository root.
 tempdir = "0.3"

--- a/src/sym_file/mod.rs
+++ b/src/sym_file/mod.rs
@@ -60,10 +60,11 @@ impl SymbolFile {
 #[cfg(test)]
 mod test {
     use super::*;
+    use std::env;
     use std::path::PathBuf;
 
     fn abs_file() -> PathBuf {
-        let mut path = PathBuf::from(env!("PWD"));
+        let mut path = env::current_dir().unwrap();
         path.push(file!());
         path
     }

--- a/src/sym_file/parser.rs
+++ b/src/sym_file/parser.rs
@@ -33,7 +33,7 @@ fn hexdigit(input:&[u8]) -> IResult<&[u8], &[u8]> {
   for (idx, item) in input.iter().enumerate() {
     if !is_hexdigit(*item) {
       if idx == 0 {
-        return Error(Err::Position(0, input))
+        return Error(Err::Position(ErrorKind::HexDigit, input))
       } else {
         return Done(&input[idx..], &input[0..idx])
       }


### PR DESCRIPTION
nom before 1.0.0 beta mistakenly includes a file whose name is not accepted by Windows, and thus the upgrade commit.

Without the second commit, there is an error when running `cargo test`:

``` text
src\sym_file/mod.rs:66:38: 66:49 error: environment variable `PWD` not defined
src\sym_file/mod.rs:66         let mut path = PathBuf::from(env!("PWD"));
                                                            ^~~~~~~~~~~
```
